### PR TITLE
feat: expand benchmarking datasets with IMGAG somatic validation data

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 
 jobs:

--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -5,6 +5,9 @@ variant-calls:
   dummy-chm: 
     path: "resources/variants/chm-eval/all.truth.bcf"
     benchmark: "chm-eval"
+  dummy-imgag:
+    path: "resources/variants/na12878-somatic/all.truth.bcf"
+    benchmark: "imgag-somatic-5perc"
 
 custom-benchmarks:
   my-custom-benchmark: # custom benchmark name, choose freely (no whitespace allowed)

--- a/workflow/resources/presets.yaml
+++ b/workflow/resources/presets.yaml
@@ -16,6 +16,30 @@ benchmarks:
     target-regions: https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/technical/reference_genome/Exome_Target_bed/S07604624_Covered_human_all_v6_plus_UTR.liftover.to.hg38.bed6.gz
     grch37: false
 
+  imgag-somatic-5perc:
+    genome: na12878-somatic
+    bam-url: https://download.imgag.de/public/validation_dataset_somatic/NA12878x3_23_NA12877_21_5.bam
+    target-regions: https://download.imgag.de/public/validation_dataset_somatic/Twist_Custom_Exome_IMGAG_v2.bed
+    grch37: false
+
+  imgag-somatic-10perc:
+    genome: na12878-somatic
+    bam-url: https://download.imgag.de/public/validation_dataset_somatic/NA12878x3_23_NA12877_21_10.bam
+    target-regions: https://download.imgag.de/public/validation_dataset_somatic/Twist_Custom_Exome_IMGAG_v2.bed
+    grch37: false
+
+  imgag-somatic-20perc:
+    genome: na12878-somatic
+    bam-url: https://download.imgag.de/public/validation_dataset_somatic/NA12878x3_23_NA12877_21_20.bam
+    target-regions: https://download.imgag.de/public/validation_dataset_somatic/Twist_Custom_Exome_IMGAG_v2.bed
+    grch37: false
+
+  imgag-somatic-40perc:
+    genome: na12878-somatic
+    bam-url: https://download.imgag.de/public/validation_dataset_somatic/NA12878x3_23_NA12877_21_40.bam
+    target-regions: https://download.imgag.de/public/validation_dataset_somatic/Twist_Custom_Exome_IMGAG_v2.bed
+    grch37: false
+
 genomes:
   na12878:
     truth:
@@ -24,6 +48,7 @@ genomes:
     confidence-regions:
       grch37: https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/NA12878_HG001/NISTv4.2.1/GRCh37/HG001_GRCh37_1_22_v4.2.1_benchmark.bed
       grch38: https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/NA12878_HG001/NISTv4.2.1/GRCh38/HG001_GRCh38_1_22_v4.2.1_benchmark.bed
+  
   chm-eval:
     archive: https://github.com/lh3/CHM-eval/releases/download/v0.5/CHM-evalkit-20180222.tar
     truth:
@@ -32,6 +57,7 @@ genomes:
     confidence-regions:
       grch38: full.38.bed.gz
       grch37: full.37m.bed.gz
+  
   seqc2-somatic:
     truth:
       grch38:
@@ -39,3 +65,9 @@ genomes:
         indels: ftp://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/release/v1.2/high-confidence_sINDEL_in_HC_regions_v1.2.vcf.gz
     confidence-regions:
       grch38: ftp://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/release/v1.2/High-Confidence_Regions_v1.2.bed
+  
+  na12878-somatic:
+    truth:
+      grch38: https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/NA12878_HG001/NISTv4.2.1/GRCh38/HG001_GRCh38_1_22_v4.2.1_benchmark.vcf.gz
+    confidence-regions:
+      grch38: https://download.imgag.de/public/validation_dataset_somatic/benchmark_region.bed

--- a/workflow/resources/presets.yaml
+++ b/workflow/resources/presets.yaml
@@ -65,9 +65,11 @@ genomes:
         indels: ftp://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/release/v1.2/high-confidence_sINDEL_in_HC_regions_v1.2.vcf.gz
     confidence-regions:
       grch38: ftp://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/release/v1.2/High-Confidence_Regions_v1.2.bed
+    somatic: true
   
   na12878-somatic:
     truth:
       grch38: https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/NA12878_HG001/NISTv4.2.1/GRCh38/HG001_GRCh38_1_22_v4.2.1_benchmark.vcf.gz
     confidence-regions:
       grch38: https://download.imgag.de/public/validation_dataset_somatic/benchmark_region.bed
+    somatic: true

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -257,7 +257,7 @@ def get_benchmark_truth(wildcards):
 def get_stratified_truth(suffix=""):
     def inner(wildcards):
         benchmark = config["variant-calls"][wildcards.callset]["benchmark"]
-        return (f"results/variants/{benchmark}.truth.cov-{{cov}}.vcf.gz{suffix}",)
+        return (f"results/variants/{benchmark}.truth.cov-{cov}.vcf.gz{suffix}",)
 
     return inner
 
@@ -269,7 +269,7 @@ def get_confidence_regions(wildcards):
 
 def get_test_regions(wildcards):
     benchmark = config["variant-calls"][wildcards.callset]["benchmark"]
-    return f"resources/regions/{benchmark}/test-regions.cov-{{cov}}.bed"
+    return f"resources/regions/{benchmark}/test-regions.cov-{cov}.bed"
 
 
 def get_rename_contig_file(wildcards):
@@ -323,7 +323,9 @@ def get_nonempty_coverages(wildcards):
 def get_somatic_flag(wildcards):
     benchmark = config["variant-calls"][wildcards.callset]["benchmark"]
     return (
-        "--squash-ploidy" if genomes[benchmarks[benchmark]["genome"]].get("somatic") else ""
+        "--squash-ploidy"
+        if genomes[benchmarks[benchmark]["genome"]].get("somatic")
+        else ""
     )
 
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -321,6 +321,10 @@ def get_nonempty_coverages(wildcards):
     return _get_nonempty_coverages(wildcards.callset)
 
 
+def get_somatic_flag(wildcards):
+    return '--squash-ploidy' if genomes[benchmarks[wildcards.callset]['genome']]['somatic'] else ''
+
+
 def get_collect_stratifications_input(wildcards):
     import json
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -322,7 +322,8 @@ def get_nonempty_coverages(wildcards):
 
 
 def get_somatic_flag(wildcards):
-    return '--squash-ploidy' if genomes[benchmarks[wildcards.callset]['genome']]['somatic'] else ''
+    benchmark = config["variant-calls"][wildcards.callset]["benchmark"]
+    return '--squash-ploidy' if genomes[benchmarks[benchmark]['genome']]['somatic'] else ''
 
 
 def get_collect_stratifications_input(wildcards):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -323,7 +323,7 @@ def get_nonempty_coverages(wildcards):
 def get_somatic_flag(wildcards):
     benchmark = config["variant-calls"][wildcards.callset]["benchmark"]
     return (
-        "--squash-ploidy" if genomes[benchmarks[benchmark]["genome"]]["somatic"] else ""
+        "--squash-ploidy" if genomes[benchmarks[benchmark]["genome"]].get("somatic") else ""
     )
 
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -83,7 +83,7 @@ def get_plot_cov_labels():
     def label(name):
         lower, upper = get_cov_interval(name)
         if upper:
-            return f"{lower}-{upper-1}"
+            return f"{lower}-{upper - 1}"
         return f"≥{lower}"
 
     return {name: label(name) for name in coverages}
@@ -134,7 +134,6 @@ def get_genome_build():
 
 def get_io_prefix(getter):
     def inner(wildcards, input, output):
-
         return getter(input, output).split(".")[0]
 
     return inner
@@ -258,7 +257,7 @@ def get_benchmark_truth(wildcards):
 def get_stratified_truth(suffix=""):
     def inner(wildcards):
         benchmark = config["variant-calls"][wildcards.callset]["benchmark"]
-        return (f"results/variants/{benchmark}.truth.cov-{{cov}}.vcf.gz{suffix}",)
+        return (f"results/variants/{benchmark}.truth.cov-{cov}.vcf.gz{suffix}",)
 
     return inner
 
@@ -270,7 +269,7 @@ def get_confidence_regions(wildcards):
 
 def get_test_regions(wildcards):
     benchmark = config["variant-calls"][wildcards.callset]["benchmark"]
-    return f"resources/regions/{benchmark}/test-regions.cov-{{cov}}.bed"
+    return f"resources/regions/{benchmark}/test-regions.cov-{cov}.bed"
 
 
 def get_rename_contig_file(wildcards):
@@ -323,7 +322,9 @@ def get_nonempty_coverages(wildcards):
 
 def get_somatic_flag(wildcards):
     benchmark = config["variant-calls"][wildcards.callset]["benchmark"]
-    return '--squash-ploidy' if genomes[benchmarks[benchmark]['genome']]['somatic'] else ''
+    return (
+        "--squash-ploidy" if genomes[benchmarks[benchmark]["genome"]]["somatic"] else ""
+    )
 
 
 def get_collect_stratifications_input(wildcards):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -257,7 +257,10 @@ def get_benchmark_truth(wildcards):
 def get_stratified_truth(suffix=""):
     def inner(wildcards):
         benchmark = config["variant-calls"][wildcards.callset]["benchmark"]
-        return (f"results/variants/{benchmark}.truth.cov-{cov}.vcf.gz{suffix}",)
+        # TODO use f-string when this is fixed: https://github.com/snakemake/snakefmt/issues/215
+        return "results/variants/{benchmark}.truth.cov-{{cov}}.vcf.gz{suffix}".format(
+            benchmark=benchmark, suffix=suffix
+        )
 
     return inner
 
@@ -269,7 +272,10 @@ def get_confidence_regions(wildcards):
 
 def get_test_regions(wildcards):
     benchmark = config["variant-calls"][wildcards.callset]["benchmark"]
-    return f"resources/regions/{benchmark}/test-regions.cov-{cov}.bed"
+    # TODO use f-string when this is fixed: https://github.com/snakemake/snakefmt/issues/215
+    return "resources/regions/{benchmark}/test-regions.cov-{{cov}}.bed".format(
+        benchmark=benchmark
+    )
 
 
 def get_rename_contig_file(wildcards):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -257,7 +257,7 @@ def get_benchmark_truth(wildcards):
 def get_stratified_truth(suffix=""):
     def inner(wildcards):
         benchmark = config["variant-calls"][wildcards.callset]["benchmark"]
-        return (f"results/variants/{benchmark}.truth.cov-{cov}.vcf.gz{suffix}",)
+        return (f"results/variants/{benchmark}.truth.cov-{{cov}}.vcf.gz{suffix}",)
 
     return inner
 
@@ -269,7 +269,7 @@ def get_confidence_regions(wildcards):
 
 def get_test_regions(wildcards):
     benchmark = config["variant-calls"][wildcards.callset]["benchmark"]
-    return f"resources/regions/{benchmark}/test-regions.cov-{cov}.bed"
+    return f"resources/regions/{benchmark}/test-regions.cov-{{cov}}.bed"
 
 
 def get_rename_contig_file(wildcards):

--- a/workflow/rules/eval.smk
+++ b/workflow/rules/eval.smk
@@ -100,14 +100,15 @@ rule benchmark_variants:
     log:
         "logs/vcfeval/{callset}/{cov}.log",
     params:
-        output=lambda w, output: os.path.dirname(output[0]),
+        output=lambda w, output: os.path.dirname(output[0]), # TODO insert param to apply somatic benchmark -> shell --squash-ploidy
+        somatic='--squash-ploidy' if genomes[benchmarks[{callset}]['genome']]['somatic'] else '', # if true: '--squash-ploidy' / if false: ''
     conda:
         "../envs/rtg-tools.yaml"
     threads: 32
     shell:
         "rm -r {params.output}; rtg vcfeval --threads {threads} --ref-overlap --all-records "
         "--output-mode ga4gh --baseline {input.truth} --calls {input.query} "
-        "--output {params.output} --template {input.genome} &> {log}"
+        "--output {params.output} --template {input.genome} {params.somatic} &> {log}"
 
 
 rule calc_precision_recall:

--- a/workflow/rules/eval.smk
+++ b/workflow/rules/eval.smk
@@ -100,8 +100,8 @@ rule benchmark_variants:
     log:
         "logs/vcfeval/{callset}/{cov}.log",
     params:
-        output=lambda w, output: os.path.dirname(output[0]), # TODO insert param to apply somatic benchmark -> shell --squash-ploidy
-        somatic='--squash-ploidy' if genomes[benchmarks[{callset}]['genome']]['somatic'] else '', # if true: '--squash-ploidy' / if false: ''
+        output=lambda w, output: os.path.dirname(output[0]), 
+        somatic=get_somatic_flag,
     conda:
         "../envs/rtg-tools.yaml"
     threads: 32

--- a/workflow/rules/eval.smk
+++ b/workflow/rules/eval.smk
@@ -100,7 +100,7 @@ rule benchmark_variants:
     log:
         "logs/vcfeval/{callset}/{cov}.log",
     params:
-        output=lambda w, output: os.path.dirname(output[0]), 
+        output=lambda w, output: os.path.dirname(output[0]),
         somatic=get_somatic_flag,
     conda:
         "../envs/rtg-tools.yaml"


### PR DESCRIPTION
Based on the [PM4Onco](https://www.uniklinik-freiburg.de/institut-fuer-medizinische-bioinformatik-und-systemmedizin/forschung/pm4onco.html) AP4 aiming to benchmark somatic and germline variant calling pipelines we added the [data provided by Marc Sturm for somatic variant calling](https://download.imgag.de/public/validation_dataset_somatic/readme.html). To run `rtg vcfeval` on results from somatic variant calls, `--squash-ploidy` is set when validation of somatic variant calls is done.