### PR TITLE
feat: only consider PASS and no-filter variants in given callsets

### DIFF
--- a/workflow/rules/eval.smk
+++ b/workflow/rules/eval.smk
@@ -13,9 +13,20 @@ rule rename_contigs:
         "-Ob -o {output} 2> {log}"
 
 
-use rule normalize_truth as normalize_calls with:
+rule remove_non_pass:
     input:
         get_callset,
+    output:
+        "results/filtered-variants/{callset}.bcf"
+    params:
+        extra="-f 'PASS,.'"
+    wrapper:
+        "v3.3.6/bio/bcftools/view"
+
+
+use rule normalize_truth as normalize_calls with:
+    input:
+        "results/filtered-variants/{callset}.bcf",
         ref="resources/reference/genome.fasta",
         ref_index="resources/reference/genome.fasta.fai",
     output:

--- a/workflow/rules/eval.smk
+++ b/workflow/rules/eval.smk
@@ -18,6 +18,8 @@ rule remove_non_pass:
         get_callset,
     output:
         "results/filtered-variants/{callset}.bcf"
+    log:
+        "logs/filter/{callset}.log"
     params:
         extra="-f 'PASS,.'"
     wrapper:

--- a/workflow/rules/eval.smk
+++ b/workflow/rules/eval.smk
@@ -17,11 +17,11 @@ rule remove_non_pass:
     input:
         get_callset,
     output:
-        "results/filtered-variants/{callset}.bcf"
+        "results/filtered-variants/{callset}.bcf",
     log:
-        "logs/filter/{callset}.log"
+        "logs/filter/{callset}.log",
     params:
-        extra="-f 'PASS,.'"
+        extra="-f 'PASS,.'",
     wrapper:
         "v3.3.6/bio/bcftools/view"
 


### PR DESCRIPTION
Added a rule that removes all variants with entries in the FILTER column other than `.` or `PASS`.