### PR TITLE
fix: modify links and add FORMAT field to make seqc2-somatic bm work

### DIFF
--- a/workflow/resources/presets.yaml
+++ b/workflow/resources/presets.yaml
@@ -10,7 +10,7 @@ benchmarks:
     bam-url: ftp://ftp.sra.ebi.ac.uk/vol1/run/ERR134/ERR1341796/CHM1_CHM13_2.bam
     grch37: false
 
-  seqc2-somatic-ea-n:
+  seqc2-somatic-ea:
     genome: seqc2-somatic
     bam-url: https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/data/WES/WES_EA_T_1.bwa.dedup.bam
     target-regions: https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/technical/reference_genome/Exome_Target_bed/S07604624_Covered_human_all_v6_plus_UTR.liftover.to.hg38.bed6.gz

--- a/workflow/resources/presets.yaml
+++ b/workflow/resources/presets.yaml
@@ -12,7 +12,7 @@ benchmarks:
 
   seqc2-somatic-ea-n:
     genome: seqc2-somatic
-    bam-url: http://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/data/WES/WES_EA_N_1.bwa.dedup.bam
+    bam-url: https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/data/WES/WES_EA_T_1.bwa.dedup.bam
     target-regions: https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/technical/reference_genome/Exome_Target_bed/S07604624_Covered_human_all_v6_plus_UTR.liftover.to.hg38.bed6.gz
     grch37: false
 
@@ -61,10 +61,10 @@ genomes:
   seqc2-somatic:
     truth:
       grch38:
-        snvs: ftp://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/release/v1.2/high-confidence_sSNV_in_HC_regions_v1.2.vcf.gz
-        indels: ftp://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/release/v1.2/high-confidence_sINDEL_in_HC_regions_v1.2.vcf.gz
+        snvs: https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/release/latest/high-confidence_sSNV_in_HC_regions_v1.2.vcf.gz
+        indels: https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/release/latest/high-confidence_sINDEL_in_HC_regions_v1.2.vcf.gz
     confidence-regions:
-      grch38: ftp://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/release/v1.2/High-Confidence_Regions_v1.2.bed
+      grch38: https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/release/latest/High-Confidence_Regions_v1.2.bed
     somatic: true
   
   na12878-somatic:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -121,6 +121,8 @@ def get_confidence_bed_cmd(wildcards, input):
 
     if input.archive:
         return f"cat {input.archive}/{bed} {unpack_cmd}"
+    if is_local_file(bed):
+        return f"cat {bed} {unpack_cmd}"
     else:
         return f"curl --insecure -L {bed} {unpack_cmd}"
 
@@ -202,10 +204,12 @@ def get_target_bed_input(wildcards):
 def get_target_bed_statement(wildcards):
     target_bed = get_benchmark(wildcards.benchmark)["target-regions"]
 
+    unpack_cmd = "| zcat " if target_bed.endswith(".gz") else ""
+
     if is_local_file(target_bed):
-        return f"cat {target_bed}"
+        return f"cat {target_bed} {unpack_cmd}"
     else:
-        return f"curl --insecure -L {target_bed}"
+        return f"curl --insecure -L {target_bed} {unpack_cmd}"
 
 
 def get_target_regions(wildcards):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -113,6 +113,21 @@ def get_truthsets(csi=False):
     return inner
 
 
+def index_truthsets(wildcards):
+    def inner(wildcards):
+        genome = genomes[wildcards.genome]
+        truthsets = genome["truth"][get_genome_build()]
+        return expand(
+            "bcftools index -f resources/variants/{genome}/{truthset}.truth.bcf",
+            genome=wildcards.genome,
+            truthset=truthsets,
+        )
+    bcf_cmd_list = inner(wildcards)
+    bcf_cmd_list.append('')
+    bcf_cmd = '\n'.join(bcf_cmd_list)
+    return bcf_cmd
+
+
 def get_confidence_bed_cmd(wildcards, input):
     genome = genomes[wildcards.genome]
     bed = genome["confidence-regions"][get_genome_build()]

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -265,7 +265,10 @@ def get_genome_truth(wildcards):
 
 def get_benchmark_truth(wildcards):
     genome = get_benchmark(wildcards.benchmark)["genome"]
-    return f"resources/variants/{genome}/all.truth.norm.bcf"
+    if get_somatic_status(wildcards):
+        return f"resources/variants/{genome}/all.truth.format-added.vcf.gz"
+    else:
+        return f"resources/variants/{genome}/all.truth.norm.bcf"
 
 
 def get_stratified_truth(suffix=""):

--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -56,16 +56,16 @@ rule get_truth:
 rule merge_truthsets:
     input:
         bcf=get_truthsets(),
-        csi=get_truthsets(csi=True), # TODO: where is this used?
     output:
         "resources/variants/{genome}.merged.truth.bcf",
     log:
         "logs/merge-truthsets/{genome}.log",
     conda:
         "../envs/tools.yaml"
+    params:
+        bcf_index_cmd=index_truthsets,
     shell:
-        # TODO: index all vcfs / bcfs before concat
-        # "for bcf in {input.bcf}; do bcftools index $bcf; done | "
+        "{params.bcf_index_cmd}"
         "bcftools concat -O b --allow-overlap {input.bcf} > {output} 2> {log}"
 
 

--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -56,7 +56,7 @@ rule get_truth:
 rule merge_truthsets:
     input:
         bcf=get_truthsets(),
-        csi=get_truthsets(csi=True),
+        csi=get_truthsets(csi=True), # TODO: where is this used?
     output:
         "resources/variants/{genome}.merged.truth.bcf",
     log:
@@ -64,7 +64,9 @@ rule merge_truthsets:
     conda:
         "../envs/tools.yaml"
     shell:
-        "bcftools concat -O b --allow-overlap {input} > {output} 2> {log}"
+        # TODO: index all vcfs / bcfs before concat
+        # "for bcf in {input.bcf}; do bcftools index $bcf; done | "
+        "bcftools concat -O b --allow-overlap {input.bcf} > {output} 2> {log}"
 
 
 rule normalize_truth:

--- a/workflow/rules/eval.smk
+++ b/workflow/rules/eval.smk
@@ -61,7 +61,7 @@ rule stratify_truth:
     output:
         "results/variants/{benchmark}.truth.cov-{cov}.vcf.gz",
     log:
-        "logs/stratify-truth.{benchmark}.{cov}.log",
+        "logs/stratify-truth/{benchmark}.{cov}.log",
     conda:
         "../envs/tools.yaml"
     shell:

--- a/workflow/rules/eval.smk
+++ b/workflow/rules/eval.smk
@@ -27,8 +27,22 @@ rule add_genotype_field:
     shell:
         # part after || gets executed if vcf-genotype-annotater fails because GT field is already present
         # bcftools convert makes sure that input for vcf-genotype-annotator is in vcf format
-        "vcf-genotype-annotator <(bcftools convert -Ov {input}) {params} 0/1 -o {output} &> {log} || cp {input} {output}"
+        "vcf-genotype-annotator <(bcftools convert -Ov {input}) {params} 0/1 -o {output} &> {log} || bcftools view {input} -Oz > {output}"
 
+rule add_format_field:
+    input: 
+        "resources/variants/{genome}/all.truth.norm.bcf"
+    output:
+        "resources/variants/{genome}/all.truth.format-added.vcf.gz"
+    log:
+        "logs/add_format_field/{genome}.log"
+    conda:
+         "../envs/vatools.yaml"
+    shell:
+        # TODO: abfragen ob field da ist bcftools view -h out.vcf.gz | grep FORMAT oder bcftools query -l all.bcf 
+        # bcftools convert makes sure that input for vcf-genotype-annotator is in vcf format
+        # adds FORMAT field with GT field and sample name 'truth'
+        "vcf-genotype-annotator <(bcftools convert -Ov {input}) truth 0/1 -o {output} &> {log}"
 
 rule remove_non_pass:
     input:

--- a/workflow/rules/eval.smk
+++ b/workflow/rules/eval.smk
@@ -39,7 +39,8 @@ rule add_format_field:
     conda:
          "../envs/vatools.yaml"
     shell:
-        # TODO: abfragen ob field da ist bcftools view -h out.vcf.gz | grep FORMAT oder bcftools query -l all.bcf 
+        # TODO: Optional - Check first if FORMAT field is present for example with
+        # TODO: bcftools view -h out.vcf.gz | grep FORMAT oder bcftools query -l all.bcf 
         # bcftools convert makes sure that input for vcf-genotype-annotator is in vcf format
         # adds FORMAT field with GT field and sample name 'truth'
         "vcf-genotype-annotator <(bcftools convert -Ov {input}) truth 0/1 -o {output} &> {log}"


### PR DESCRIPTION
This is a draft PR until I confirmed that the bm works with vcf files produced by a variant caller, not only with the truth vcf.