### PR TITLE
fix: use latest datavzrd wrapper, integrating templating of config, thereby avoiding leaks of local storage paths into datavzrd config

### DIFF
--- a/workflow/resources/datavzrd/fp-fn-config.yte.yaml
+++ b/workflow/resources/datavzrd/fp-fn-config.yte.yaml
@@ -1,3 +1,5 @@
+__use_yte__: true
+
 __definitions__:
   - import os
   - import pandas as pd

--- a/workflow/resources/datavzrd/precision-recall-config.yte.yaml
+++ b/workflow/resources/datavzrd/precision-recall-config.yte.yaml
@@ -1,3 +1,5 @@
+__use_yte__: true
+
 __variables__:
   green: "#74c476"
   orange: "#fd8d3c"

--- a/workflow/resources/datavzrd/precision-recall-config.yte.yaml
+++ b/workflow/resources/datavzrd/precision-recall-config.yte.yaml
@@ -9,7 +9,7 @@ default-view: results-table
 
 datasets:
   results:
-    path: ?input.dataset
+    path: ?input.table
     separator: "\t"
     links:
       link to table:

--- a/workflow/rules/eval.smk
+++ b/workflow/rules/eval.smk
@@ -251,10 +251,13 @@ rule render_precision_recall_report_config:
     params:
         somatic=get_somatic_status,
     output:
-        temp("results/datavzrd-config/precision-recall/{benchmark}/{vartype}.config.yaml"),
+        temp(
+            "results/datavzrd-config/precision-recall/{benchmark}/{vartype}.config.yaml"
+        ),
     log:
         "logs/yte/datavzrd-config/precision-recall/{benchmark}/{vartype}.log",
-    group: "report_precision_recall"
+    group:
+        "report_precision_recall"
     template_engine:
         "yte"
 
@@ -272,7 +275,8 @@ rule report_precision_recall:
         ),
     log:
         "logs/datavzrd/precision-recall/{benchmark}/{vartype}.log",
-    group: "report_precision_recall"
+    group:
+        "report_precision_recall"
     wrapper:
         "v2.13.0/utils/datavzrd"
 
@@ -324,12 +328,15 @@ rule render_fp_fn_report_config:
         dependency_sorting_datasets="results/fp-fn/genomes/{genome}/{cov}/{classification}/dependency-sorting",
         template=workflow.source_path("../resources/datavzrd/fp-fn-config.yte.yaml"),
     output:
-        temp("results/datavzrd-config/fp-fn/{genome}/{cov}/{classification}.config.yaml"),
+        temp(
+            "results/datavzrd-config/fp-fn/{genome}/{cov}/{classification}.config.yaml"
+        ),
     params:
         labels=lambda w: get_callsets_labels(get_genome_callsets(w.genome)),
     log:
         "logs/yte/datavzrd-config/fp-fn/{genome}/{cov}/{classification}.log",
-    group: "report_fp_fn"
+    group:
+        "report_fp_fn"
     template_engine:
         "yte"
 
@@ -349,6 +356,7 @@ rule report_fp_fn:
         ),
     log:
         "logs/datavzrd/fp-fn/{genome}/{cov}/{classification}.log",
-    group: "report_fp_fn"
+    group:
+        "report_fp_fn"
     wrapper:
         "v2.13.0/utils/datavzrd"

--- a/workflow/rules/eval.smk
+++ b/workflow/rules/eval.smk
@@ -242,29 +242,11 @@ rule collect_precision_recall:
         "../scripts/collect-precision-recall.py"
 
 
-rule render_precision_recall_report_config:
-    input:
-        dataset="results/precision-recall/benchmarks/{benchmark}.{vartype}.tsv",
-        template=workflow.source_path(
-            "../resources/datavzrd/precision-recall-config.yte.yaml"
-        ),
-    params:
-        somatic=get_somatic_status,
-    output:
-        temp(
-            "results/datavzrd-config/precision-recall/{benchmark}/{vartype}.config.yaml"
-        ),
-    log:
-        "logs/yte/datavzrd-config/precision-recall/{benchmark}/{vartype}.log",
-    group:
-        "report_precision_recall"
-    template_engine:
-        "yte"
-
-
 rule report_precision_recall:
     input:
-        config="results/datavzrd-config/precision-recall/{benchmark}/{vartype}.config.yaml",
+        config=workflow.source_path(
+            "../resources/datavzrd/precision-recall-config.yte.yaml"
+        ),
         table="results/precision-recall/benchmarks/{benchmark}.{vartype}.tsv",
     output:
         report(
@@ -275,10 +257,10 @@ rule report_precision_recall:
         ),
     log:
         "logs/datavzrd/precision-recall/{benchmark}/{vartype}.log",
-    group:
-        "report_precision_recall"
+    params:
+        somatic=get_somatic_status,
     wrapper:
-        "v2.13.0/utils/datavzrd"
+        "v3.10.1/utils/datavzrd"
 
 
 rule extract_fp_fn:
@@ -322,30 +304,11 @@ rule collect_fp_fn:
         "../scripts/collect-fp-fn.py"
 
 
-rule render_fp_fn_report_config:
-    input:
-        main_dataset="results/fp-fn/genomes/{genome}/{cov}/{classification}/main.tsv",
-        dependency_sorting_datasets="results/fp-fn/genomes/{genome}/{cov}/{classification}/dependency-sorting",
-        template=workflow.source_path("../resources/datavzrd/fp-fn-config.yte.yaml"),
-    output:
-        temp(
-            "results/datavzrd-config/fp-fn/{genome}/{cov}/{classification}.config.yaml"
-        ),
-    params:
-        labels=lambda w: get_callsets_labels(get_genome_callsets(w.genome)),
-    log:
-        "logs/yte/datavzrd-config/fp-fn/{genome}/{cov}/{classification}.log",
-    group:
-        "report_fp_fn"
-    template_engine:
-        "yte"
-
-
 rule report_fp_fn:
     input:
         main_dataset="results/fp-fn/genomes/{genome}/{cov}/{classification}/main.tsv",
         dependency_sorting_datasets="results/fp-fn/genomes/{genome}/{cov}/{classification}/dependency-sorting",
-        config="results/datavzrd-config/fp-fn/{genome}/{cov}/{classification}.config.yaml",
+        config=workflow.source_path("../resources/datavzrd/fp-fn-config.yte.yaml"),
     output:
         report(
             directory("results/report/fp-fn/{genome}/{cov}/{classification}"),
@@ -356,7 +319,7 @@ rule report_fp_fn:
         ),
     log:
         "logs/datavzrd/fp-fn/{genome}/{cov}/{classification}.log",
-    group:
-        "report_fp_fn"
+    params:
+        labels=lambda w: get_callsets_labels(get_genome_callsets(w.genome)),
     wrapper:
-        "v2.13.0/utils/datavzrd"
+        "v3.10.1/utils/datavzrd"

--- a/workflow/rules/eval.smk
+++ b/workflow/rules/eval.smk
@@ -251,9 +251,10 @@ rule render_precision_recall_report_config:
     params:
         somatic=get_somatic_status,
     output:
-        "results/datavzrd-config/precision-recall/{benchmark}/{vartype}.config.yaml",
+        temp("results/datavzrd-config/precision-recall/{benchmark}/{vartype}.config.yaml"),
     log:
         "logs/yte/datavzrd-config/precision-recall/{benchmark}/{vartype}.log",
+    group: "report_precision_recall"
     template_engine:
         "yte"
 
@@ -271,6 +272,7 @@ rule report_precision_recall:
         ),
     log:
         "logs/datavzrd/precision-recall/{benchmark}/{vartype}.log",
+    group: "report_precision_recall"
     wrapper:
         "v2.13.0/utils/datavzrd"
 
@@ -322,11 +324,12 @@ rule render_fp_fn_report_config:
         dependency_sorting_datasets="results/fp-fn/genomes/{genome}/{cov}/{classification}/dependency-sorting",
         template=workflow.source_path("../resources/datavzrd/fp-fn-config.yte.yaml"),
     output:
-        "results/datavzrd-config/fp-fn/{genome}/{cov}/{classification}.config.yaml",
+        temp("results/datavzrd-config/fp-fn/{genome}/{cov}/{classification}.config.yaml"),
     params:
         labels=lambda w: get_callsets_labels(get_genome_callsets(w.genome)),
     log:
         "logs/yte/datavzrd-config/fp-fn/{genome}/{cov}/{classification}.log",
+    group: "report_fp_fn"
     template_engine:
         "yte"
 
@@ -346,5 +349,6 @@ rule report_fp_fn:
         ),
     log:
         "logs/datavzrd/fp-fn/{genome}/{cov}/{classification}.log",
+    group: "report_fp_fn"
     wrapper:
         "v2.13.0/utils/datavzrd"


### PR DESCRIPTION
Otherwise, the consuming rule can fail on certain systems where local storage paths are job specific. Future Snakemake releases will protect against this by checking the output of template engine rules for such leaks.