### PR TITLE
fix: change bm names to adhere to naming scheme in pm4onco

### DIFF
--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -7,7 +7,7 @@ variant-calls:
     benchmark: "chm-eval"
   dummy-imgag:
     path: "resources/variants/na12878-somatic/all.truth.bcf"
-    benchmark: "imgag-somatic-5perc"
+    benchmark: "imgag-5"
     tumor_sample_name: "HG001"
   dummy-seqc2:
     path: "resources/variants/seqc2-somatic/all.truth.format-added.vcf.gz"

--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -11,7 +11,7 @@ variant-calls:
     tumor_sample_name: "HG001"
   dummy-seqc2:
     path: "resources/variants/seqc2-somatic/all.truth.format-added.vcf.gz"
-    benchmark: "seqc2-somatic-ea"
+    benchmark: "seqc2-wes"
     tumor_sample_name: "truth"
     vaf-field: 
       - INFO

--- a/workflow/resources/presets.yaml
+++ b/workflow/resources/presets.yaml
@@ -10,7 +10,7 @@ benchmarks:
     bam-url: ftp://ftp.sra.ebi.ac.uk/vol1/run/ERR134/ERR1341796/CHM1_CHM13_2.bam
     grch37: false
 
-  seqc2-somatic-ea:
+  seqc2-wes:
     genome: seqc2-somatic
     bam-url: https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/data/WES/WES_EA_T_1.bwa.dedup.bam
     target-regions: https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/technical/reference_genome/Exome_Target_bed/S07604624_Covered_human_all_v6_plus_UTR.liftover.to.hg38.bed6.gz
@@ -19,25 +19,25 @@ benchmarks:
       - INFO # either FORMAT or INFO
       - TVAF # name of tumor variant allele frequency
 
-  imgag-somatic-5perc:
+  imgag-5:
     genome: na12878-somatic
     bam-url: https://download.imgag.de/public/validation_dataset_somatic/NA12878x3_23_NA12877_21_5.bam
     target-regions: https://download.imgag.de/public/validation_dataset_somatic/Twist_Custom_Exome_IMGAG_v2.bed
     grch37: false
 
-  imgag-somatic-10perc:
+  imgag-10:
     genome: na12878-somatic
     bam-url: https://download.imgag.de/public/validation_dataset_somatic/NA12878x3_23_NA12877_21_10.bam
     target-regions: https://download.imgag.de/public/validation_dataset_somatic/Twist_Custom_Exome_IMGAG_v2.bed
     grch37: false
 
-  imgag-somatic-20perc:
+  imgag-20:
     genome: na12878-somatic
     bam-url: https://download.imgag.de/public/validation_dataset_somatic/NA12878x3_23_NA12877_21_20.bam
     target-regions: https://download.imgag.de/public/validation_dataset_somatic/Twist_Custom_Exome_IMGAG_v2.bed
     grch37: false
 
-  imgag-somatic-40perc:
+  imgag-40:
     genome: na12878-somatic
     bam-url: https://download.imgag.de/public/validation_dataset_somatic/NA12878x3_23_NA12877_21_40.bam
     target-regions: https://download.imgag.de/public/validation_dataset_somatic/Twist_Custom_Exome_IMGAG_v2.bed


### PR DESCRIPTION
We decided to use the following naming schemes in the PM4Onco benchmark for the callsets:

`seqc2-[ffpe, wgs, wes]-[location]-[caller]-[snv, indel, _ ]`

`imgag-[5, 10, 20, 40]-[location]-[caller]-[snv, indel, _ ]`

To stay consistent, the benchmarks should reflect this scheme. The benchmarks `seqc2-ffpe` and `seqc2-wgs` will be added with another PR.