### PR TITLE
fix: Split intersection with target region and normalize calls in separate rules.

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -93,7 +93,7 @@ def get_plot_cov_labels():  # TODO check if ever used anywhere
     def label(name):
         lower, upper = get_cov_interval(name)
         if upper:
-            return f"{lower}-{upper - 1}"
+            return f"{lower}-{upper-1}"
         return f"≥{lower}"
 
     return {name: label(name) for name in low_coverages}
@@ -258,6 +258,13 @@ def get_target_regions(wildcards):
             return f"resources/regions/{benchmark_name}/target-regions.bed"
         else:
             return []
+
+
+def intersect_calls(wildcards):
+    if get_target_regions(wildcards) == []:
+        return False
+    else:
+        return True
 
 
 def get_target_regions_intersect_statement(wildcards, input):

--- a/workflow/rules/eval.smk
+++ b/workflow/rules/eval.smk
@@ -96,7 +96,7 @@ rule intersect_calls_with_target_regions:
         bcf="results/filtered-variants/{callset}.bcf",
         regions=get_target_regions,
     output:
-        "results/normalized-variants/{callset}_intersected.vcf.gz",
+        pipe("results/normalized-variants/{callset}_intersected.vcf"),
     log:
         "logs/intersect-calls/{callset}.log",
     conda:
@@ -110,7 +110,7 @@ rule normalize_calls:
     input:
         calls=branch(
             intersect_calls,
-            then="results/normalized-variants/{callset}_intersected.vcf.gz",
+            then="results/normalized-variants/{callset}_intersected.vcf",
             otherwise="results/filtered-variants/{callset}.bcf",
         ),
         ref="resources/reference/genome.fasta",


### PR DESCRIPTION
Separate the bedtools intersect command and bcftools norm in different rules. Previous solution did not work if there were no target regions.