### PR TITLE
feat: automate picking of rename file based on reference genome used for calling + setup for more than 2 reference genomes

### DIFF
--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -38,4 +38,4 @@ custom-benchmarks:
 
 limit-reads: true
 
-grch37: false
+reference-genome: grch38

--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -3,15 +3,18 @@ variant-calls:
     path: "resources/variants/na12878/all.truth.bcf"
     benchmark: "giab-na12878-exome"
     genome-build: grch38
+    rename-contigs: false
   dummy-chm: 
     path: "resources/variants/chm-eval/all.truth.bcf"
     benchmark: "chm-eval"
     genome-build: grch38
+    rename-contigs: false
   dummy-imgag:
     path: "resources/variants/na12878-somatic/all.truth.bcf"
     benchmark: "imgag-5"
     tumor_sample_name: "HG001"
     genome-build: grch38
+    rename-contigs: false
   dummy-seqc2:
     path: "resources/variants/seqc2-somatic/all.truth.format-added.vcf.gz"
     benchmark: "seqc2-wes"
@@ -20,6 +23,7 @@ variant-calls:
       field: INFO
       name: TVAF
     genome-build: grch38
+    rename-contigs: false
 
 custom-benchmarks:
   my-custom-benchmark: # custom benchmark name, choose freely (no whitespace allowed)
@@ -29,7 +33,7 @@ custom-benchmarks:
       - path/to/1.fq
       - path/to/2.fq
     target-regions: path/to/regions.bed
-    # whether given target regions are on hg19
+    # given target regions are on grch38 or grch37
     genome-build: grch38
 
 limit-reads: true

--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -2,13 +2,16 @@ variant-calls:
   dummy-giab:
     path: "resources/variants/na12878/all.truth.bcf"
     benchmark: "giab-na12878-exome"
+    genome-build: grch38
   dummy-chm: 
     path: "resources/variants/chm-eval/all.truth.bcf"
     benchmark: "chm-eval"
+    genome-build: grch38
   dummy-imgag:
     path: "resources/variants/na12878-somatic/all.truth.bcf"
     benchmark: "imgag-5"
     tumor_sample_name: "HG001"
+    genome-build: grch38
   dummy-seqc2:
     path: "resources/variants/seqc2-somatic/all.truth.format-added.vcf.gz"
     benchmark: "seqc2-wes"
@@ -16,6 +19,7 @@ variant-calls:
     vaf-field: 
       field: INFO
       name: TVAF
+    genome-build: grch38
 
 custom-benchmarks:
   my-custom-benchmark: # custom benchmark name, choose freely (no whitespace allowed)
@@ -26,7 +30,7 @@ custom-benchmarks:
       - path/to/2.fq
     target-regions: path/to/regions.bed
     # whether given target regions are on hg19
-    grch37: false
+    genome-build: grch38
 
 limit-reads: true
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,8 +17,9 @@ variant-calls:
     vaf-field: # needs to be checked with bcftools view -h
       field: FORMAT
       name: AF
-    # Set to grch37 if grch37 was used as reference for variant calling, 
-    # then a liftover to grch38 will be performed
+    # Set the reference genome used for variant calling
+    # Supported values: grch37, grch38
+    # A liftover to grch38 will be performed if needed
     genome-build: grch38
     # Set to true if your file needs to be translated from UCSC to Ensembl
     # or point to a file containing contig name replacements
@@ -46,8 +47,8 @@ custom-benchmarks:
 # Optional for testing: limit to first 10000 reads
 limit-reads: false
 
-# whether evaluation shall happen on grch37
-grch37: false
+# whether evaluation shall happen on grch37 or grch38
+reference-genome: grch38
 
 # maximum number of entries in the FP and FN tables
 # (this might be exceeded because each chromosome is always fully included)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -14,14 +14,14 @@ variant-calls:
     tumor_sample_name: <tumor-sample-name> # via bcftools query -l <your-vcf>
     # benchmark to use (giab-NA12878-exome or any custom benchmark name provided from below)
     benchmark: giab-na12878-exome
-    # Uncomment and point to file containing contig name replacements
-    # as needed for 'bcftools annotate --rename-chrs'
-    # rename-contigs: path/to/rename-contigs.txt
     vaf-field: # needs to be checked with bcftools view -h
       field: FORMAT
       name: AF
-    # Uncomment if callset was produced using grch37 as reference, then a liftover to grch38 will be performed
-    # grch37: true
+    # Set to grch37 if grch37 was used as reference, then a liftover to grch38 will be performed
+    genome-build: grch38
+    # Set to true if your file needs to be translated from UCSC to Ensembl
+    # or point to a file containing contig name replacements
+    rename-contigs: false
 
 # Optional custom benchmarks
 custom-benchmarks:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,7 +17,8 @@ variant-calls:
     vaf-field: # needs to be checked with bcftools view -h
       field: FORMAT
       name: AF
-    # Set to grch37 if grch37 was used as reference, then a liftover to grch38 will be performed
+    # Set to grch37 if grch37 was used as reference for variant calling, 
+    # then a liftover to grch38 will be performed
     genome-build: grch38
     # Set to true if your file needs to be translated from UCSC to Ensembl
     # or point to a file containing contig name replacements

--- a/workflow/resources/presets.yaml
+++ b/workflow/resources/presets.yaml
@@ -4,11 +4,13 @@ benchmarks:
     bam-url: ftp://ftp-trace.ncbi.nih.gov/ReferenceSamples/giab/data/NA12878/Nebraska_NA12878_HG001_TruSeq_Exome/NIST-hg001-7001-ready.bam
     target-regions: ftp://ftp-trace.ncbi.nih.gov/ReferenceSamples/giab/data/NA12878/Nebraska_NA12878_HG001_TruSeq_Exome/TruSeq_exome_targeted_regions.hg19.bed
     grch37: true
+    high-coverage: false
 
   chm-eval:
     genome: chm-eval
     bam-url: ftp://ftp.sra.ebi.ac.uk/vol1/run/ERR134/ERR1341796/CHM1_CHM13_2.bam
     grch37: false
+    high-coverage: false
 
   seqc2-wes:
     genome: seqc2-somatic

--- a/workflow/resources/presets.yaml
+++ b/workflow/resources/presets.yaml
@@ -29,7 +29,7 @@ benchmarks:
     vaf-field:
       field: INFO # either FORMAT or INFO
       name: TVAF # name of tumor variant allele frequency
-    high-coverage: true
+    high-coverage: false
 
   seqc2-ffpe:
     genome: seqc2-somatic

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -66,7 +66,10 @@ def get_reference_genome_build():
     elif config["reference-genome"] == "grch38":
         return "GRCh38"
     else:
-        raise ValueError(f"Invalid reference genome build: {config['reference-genome']}. Must be one of: grch37, grch38")
+        raise ValueError(
+            f"Invalid reference genome build: {config['reference-genome']}. Must be one of: grch37, grch38"
+        )
+
 
 def get_archive_input(wildcards):
     genome = genomes[wildcards.genome]

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -25,11 +25,16 @@ used_genomes = {benchmarks[benchmark]["genome"] for benchmark in used_benchmarks
 
 
 # TODO: can this be removed?
-if any(
-    callset["benchmark"] == "giab-NA12878-exome" for callset in callsets.values()
-) and config.get("grch37"):
+if (
+    any(
+        callset["benchmark"] == "giab-NA12878-exome"
+        for callset in callsets.values()
+        # ) and config.get("grch37"):
+    )
+    and config["reference-genome"] != "grch38"
+):
     raise ValueError(
-        "grch37 must be set to false in the config if giab-NA12878-exome benchmark is used"
+        "grch38 must be set as reference-genome in the config if giab-NA12878-exome benchmark is used"
     )
 
 
@@ -149,10 +154,11 @@ def get_confidence_bed_cmd(wildcards, input):
 
 # TODO: update this to allow more than two reference genomes
 def get_genome_build():
-    if config.get("grch37"):
-        return "grch37"
-    else:
-        return "grch38"
+    return config["reference-genome"]
+    # if config.get("grch37"):
+    #     return "grch37"
+    # else:
+    #     return "grch38"
 
 
 def get_io_prefix(getter):
@@ -281,7 +287,7 @@ def get_target_regions_intersect_statement(wildcards, input):
 def get_liftover_statement(wildcards, input, output):
     benchmark = get_benchmark(wildcards.benchmark)
 
-    if benchmark["grch37"] and not config.get("grch37"):
+    if benchmark["grch37"] and not config["referemce-genome"] == "grch37":
         return f"| liftOver /dev/stdin {input.liftover} {output} /dev/null"
     else:
         return f"> {output}"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -24,7 +24,7 @@ used_callsets = {callset for callset in callsets.keys()}
 used_genomes = {benchmarks[benchmark]["genome"] for benchmark in used_benchmarks}
 
 
-#TODO: can this be removed?
+# TODO: can this be removed?
 if any(
     callset["benchmark"] == "giab-NA12878-exome" for callset in callsets.values()
 ) and config.get("grch37"):
@@ -337,12 +337,22 @@ def get_test_regions(wildcards):
 
 
 def get_rename_contig_file(wildcards):
-    if config["variant-calls"][wildcards.callset]["genome-build"] == "grch37" and config["variant-calls"][wildcards.callset]["rename-contigs"]:
-        return workflow.source_path("../resources/rename-contigs/grch37_ucsc2ensembl.txt")
-    if config["variant-calls"][wildcards.callset]["genome-build"] == "grch38" and config["variant-calls"][wildcards.callset]["rename-contigs"]:
-        return workflow.source_path("../resources/rename-contigs/grch38_ucsc2ensembl.txt")
+    if (
+        config["variant-calls"][wildcards.callset]["genome-build"] == "grch37"
+        and config["variant-calls"][wildcards.callset]["rename-contigs"]
+    ):
+        return workflow.source_path(
+            "../resources/rename-contigs/grch37_ucsc2ensembl.txt"
+        )
+    if (
+        config["variant-calls"][wildcards.callset]["genome-build"] == "grch38"
+        and config["variant-calls"][wildcards.callset]["rename-contigs"]
+    ):
+        return workflow.source_path(
+            "../resources/rename-contigs/grch38_ucsc2ensembl.txt"
+        )
     else:
-        config["variant-calls"][wildcards.callset]["rename-contigs"]
+        return config["variant-calls"][wildcards.callset]["rename-contigs"]
 
 
 def get_callset_subcategory(wildcards):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -104,7 +104,7 @@ def get_plot_cov_labels():  # TODO check if ever used anywhere
 
 def get_truth_url(wildcards, input):
     genome = genomes[wildcards.genome]
-    truth = genome["truth"][get_genome_build(wildcards)]
+    truth = genome["truth"][get_genome_build()]
     if isinstance(truth, dict):
         truth = truth[wildcards.truthset]
     if input.archive:
@@ -116,7 +116,7 @@ def get_truth_url(wildcards, input):
 def get_truthsets(csi=False):
     def inner(wildcards):
         genome = genomes[wildcards.genome]
-        truthsets = genome["truth"][get_genome_build(wildcards)]
+        truthsets = genome["truth"][get_genome_build()]
         if csi:
             return expand(
                 "resources/variants/{genome}/{truthset}.truth.bcf.csi",
@@ -147,8 +147,11 @@ def get_confidence_bed_cmd(wildcards, input):
         return f"curl --insecure -L {bed} {unpack_cmd}"
 
 
-def get_genome_build(wildcards):
-    return config["variant-calls"][wildcards.callset]["genome-build"]
+def get_genome_build():
+    if config.get("grch37"):
+        return "grch37"
+    else:
+        return "grch38"
 
 
 def get_io_prefix(getter):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -62,6 +62,14 @@ common_src = [
     workflow.source_path("../scripts/common/classification.py"),
 ]
 
+def get_reference_genome_build():
+    if config["reference-genome"] == "grch37":
+        return "GRCh37"
+    elif config["reference-genome"] == "grch38":
+        return "GRCh38"
+    else:
+        return null
+
 
 def get_archive_input(wildcards):
     genome = genomes[wildcards.genome]
@@ -287,7 +295,7 @@ def get_target_regions_intersect_statement(wildcards, input):
 def get_liftover_statement(wildcards, input, output):
     benchmark = get_benchmark(wildcards.benchmark)
 
-    if benchmark["grch37"] and not config["referemce-genome"] == "grch37":
+    if benchmark["grch37"] and not config["reference-genome"] == "grch37":
         return f"| liftOver /dev/stdin {input.liftover} {output} /dev/null"
     else:
         return f"> {output}"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -59,13 +59,14 @@ common_src = [
 
 
 def get_reference_genome_build():
+    if "reference-genome" not in config:
+        raise ValueError("Missing required configuration: reference-genome")
     if config["reference-genome"] == "grch37":
         return "GRCh37"
     elif config["reference-genome"] == "grch38":
         return "GRCh38"
     else:
-        return null
-
+        raise ValueError(f"Invalid reference genome build: {config['reference-genome']}. Must be one of: grch37, grch38")
 
 def get_archive_input(wildcards):
     genome = genomes[wildcards.genome]

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -24,13 +24,8 @@ used_callsets = {callset for callset in callsets.keys()}
 used_genomes = {benchmarks[benchmark]["genome"] for benchmark in used_benchmarks}
 
 
-# TODO: can this be removed?
 if (
-    any(
-        callset["benchmark"] == "giab-NA12878-exome"
-        for callset in callsets.values()
-        # ) and config.get("grch37"):
-    )
+    any(callset["benchmark"] == "giab-NA12878-exome" for callset in callsets.values())
     and config["reference-genome"] != "grch38"
 ):
     raise ValueError(
@@ -161,13 +156,8 @@ def get_confidence_bed_cmd(wildcards, input):
         return f"curl --insecure -L {bed} {unpack_cmd}"
 
 
-# TODO: update this to allow more than two reference genomes
 def get_genome_build():
     return config["reference-genome"]
-    # if config.get("grch37"):
-    #     return "grch37"
-    # else:
-    #     return "grch38"
 
 
 def get_io_prefix(getter):
@@ -295,7 +285,6 @@ def get_target_regions_intersect_statement(wildcards, input):
 
 def get_liftover_statement(wildcards, input, output):
     benchmark = get_benchmark(wildcards.benchmark)
-
     if benchmark["grch37"] and not config["reference-genome"] == "grch37":
         return f"| liftOver /dev/stdin {input.liftover} {output} /dev/null"
     else:
@@ -425,7 +414,6 @@ def get_nonempty_coverages(wildcards):
 
 def get_coverages(wildcards):
     if hasattr(wildcards, "benchmark"):
-        # benchmark = get_benchmark(wildcards.benchmark)
         high_cov_status = benchmarks[wildcards.benchmark].get("high-coverage")
     else:
         benchmark = config["variant-calls"][wildcards.callset]["benchmark"]

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -146,7 +146,7 @@ def get_confidence_bed_cmd(wildcards, input):
     else:
         return f"curl --insecure -L {bed} {unpack_cmd}"
 
-
+# TODO: update this to allow more than two reference genomes
 def get_genome_build():
     if config.get("grch37"):
         return "grch37"
@@ -191,9 +191,9 @@ def get_callset(wildcards):
     callset = config["variant-calls"][wildcards.callset]
     if get_somatic_status(wildcards):
         return "results/normalized-variants/{callset}.gt-added.vcf.gz"
-    elif "rename-contigs" in callset:
+    elif callset["rename-contigs"] != False:
         return "results/normalized-variants/{callset}.replaced-contigs.vcf.gz"
-    elif "grch37" in callset:
+    elif callset["genome-build"] == "grch37":
         return "results/normalized-variants/{callset}.lifted.vcf.gz"
     else:
         return get_raw_callset(wildcards)
@@ -203,7 +203,7 @@ def get_callset_correct_contigs(wildcards):
     callset = config["variant-calls"][wildcards.callset]
     if "rename-contigs" in callset:
         return "results/normalized-variants/{callset}.replaced-contigs.vcf.gz"
-    elif "grch37" in callset:
+    elif callset["genome-build"] == "grch37":
         return "results/normalized-variants/{callset}.lifted.vcf.gz"
     else:
         return get_raw_callset(wildcards)
@@ -211,9 +211,9 @@ def get_callset_correct_contigs(wildcards):
 
 def get_callset_correct_contigs_liftover(wildcards):
     callset = config["variant-calls"][wildcards.callset]
-    if "grch37" in callset:
+    if callset["genome-build"] == "grch37":
         return "results/normalized-variants/{callset}.lifted.vcf.gz"
-    elif "rename-contigs" in callset:
+    elif callset["rename-contigs"] != False:
         return "results/normalized-variants/{callset}.replaced-contigs.vcf.gz"
     else:
         return get_raw_callset(wildcards)

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -62,6 +62,7 @@ common_src = [
     workflow.source_path("../scripts/common/classification.py"),
 ]
 
+
 def get_reference_genome_build():
     if config["reference-genome"] == "grch37":
         return "GRCh37"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -161,6 +161,8 @@ def get_confidence_bed_cmd(wildcards, input):
 
 
 def get_genome_build():
+    if "reference-genome" not in config:
+        raise ValueError("Missing required configuration: reference-genome")
     return config["reference-genome"]
 
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -146,6 +146,7 @@ def get_confidence_bed_cmd(wildcards, input):
     else:
         return f"curl --insecure -L {bed} {unpack_cmd}"
 
+
 # TODO: update this to allow more than two reference genomes
 def get_genome_build():
     if config.get("grch37"):

--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -158,7 +158,7 @@ rule get_reference:
     params:
         species="homo_sapiens",
         datatype="dna",
-        build="GRCh37" if config["grch37"] else "GRCh38",
+        build=get_reference_genome_build(),
         release="104",
         chromosome="1" if config.get("limit-reads") else None,
     log:

--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -158,7 +158,7 @@ rule get_reference:
     params:
         species="homo_sapiens",
         datatype="dna",
-        build=get_reference_genome_build(),
+        build=get_reference_genome_build,
         release="104",
         chromosome="1" if config.get("limit-reads") else None,
     log:

--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -158,7 +158,7 @@ rule get_reference:
     params:
         species="homo_sapiens",
         datatype="dna",
-        build=get_reference_genome_build,
+        build=get_reference_genome_build(),
         release="104",
         chromosome="1" if config.get("limit-reads") else None,
     log:


### PR DESCRIPTION
Related to #99 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Configuration Updates**
  - Added explicit genome build configuration (GRCh38) across multiple entries.
  - Disabled contig renaming for variant calls.
  - Updated benchmark configurations to specify coverage status for specific benchmarks.

- **Workflow Improvements**
  - Enhanced error handling and validation for benchmark configurations.
  - Improved logic for genome build and contig handling.
  - General code cleanup for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->