### PR TITLE
feat: split get_reads in two rules

### DIFF
--- a/workflow/resources/presets.yaml
+++ b/workflow/resources/presets.yaml
@@ -2,6 +2,7 @@ benchmarks:
   giab-na12878-exome:
     genome: na12878
     bam-url: ftp://ftp-trace.ncbi.nih.gov/ReferenceSamples/giab/data/NA12878/Nebraska_NA12878_HG001_TruSeq_Exome/NIST-hg001-7001-ready.bam
+    bam-md5: 634bd46801101d435025c797f96f608a
     target-regions: ftp://ftp-trace.ncbi.nih.gov/ReferenceSamples/giab/data/NA12878/Nebraska_NA12878_HG001_TruSeq_Exome/TruSeq_exome_targeted_regions.hg19.bed
     grch37: true
     high-coverage: false

--- a/workflow/resources/presets.yaml
+++ b/workflow/resources/presets.yaml
@@ -15,6 +15,7 @@ benchmarks:
   seqc2-wes:
     genome: seqc2-somatic
     bam-url: https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/data/WES/WES_EA_T_1.bwa.dedup.bam
+    bam-md5: 91ab8215bdefc829f7c4955a84227166
     target-regions: https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/technical/reference_genome/Exome_Target_bed/S07604624_Covered_human_all_v6_plus_UTR.liftover.to.hg38.bed6.gz
     grch37: false
     vaf-field:
@@ -25,6 +26,7 @@ benchmarks:
   seqc2-wgs:
     genome: seqc2-somatic
     bam-url: https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/data/WGS/WGS_NS_T_1.bwa.dedup.bam
+    bam-md5: ddc0cf78eb1fa9a59eab284f904e419
     grch37: false
     vaf-field:
       field: INFO # either FORMAT or INFO
@@ -34,6 +36,7 @@ benchmarks:
   seqc2-ffpe:
     genome: seqc2-somatic
     bam-url: https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/data/FFX/FFX_IL_T_24h_1.bwa.dedup.bam
+    bam-md5: 0d241fba856e0a7487dacdf65912a493
     target-regions: https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/technical/reference_genome/Exome_Target_bed/S07604624_Covered_human_all_v6_plus_UTR.liftover.to.hg38.bed6.gz
     grch37: false
     vaf-field:


### PR DESCRIPTION
Separate download of bam file and splitting the bam into reads in two rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated step for downloading BAM files, with improved reliability and concurrency.
- **Improvements**
  - The process for extracting reads now works from locally downloaded BAM files, enhancing workflow clarity and control.
  - Log file locations and naming have been updated for better organization.
  - Added checksum verification for BAM files in benchmark configurations to ensure data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->