### PR TITLE
fix: use buffered and script based get-reads implementation

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -48,7 +48,7 @@ custom-benchmarks:
     # whether given target regions are on hg19
     grch37: false
 
-# Optional for testing: limit to first 10000 reads
+# Optional for testing: limit to first 100000 reads
 limit-reads: false
 
 # whether evaluation shall happen on grch37 or grch38

--- a/workflow/envs/pysam.yaml
+++ b/workflow/envs/pysam.yaml
@@ -6,3 +6,4 @@ dependencies:
   - python =3.9
   - pysam =0.18
   - pandas =1.3
+  - dnaio =1.2

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -334,13 +334,6 @@ def get_liftover_statement(wildcards, input, output):
         return f"> {output}"
 
 
-def get_read_limit_param(wildcards, input):
-    if config.get("limit-reads"):
-        return "| head -n 110000"  # a bit more than 100000 reads because we also have the header
-    else:
-        return ""
-
-
 def get_benchmark(benchmark):
     try:
         return benchmarks[benchmark]

--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -3,7 +3,11 @@ rule get_reads:
         r1="resources/reads/{benchmark}.1.fq",
         r2="resources/reads/{benchmark}.2.fq",
     params:
-        limit=branch(lookup("limit-reads", within=config, default=False), then=100000, otherwise=None),
+        limit=branch(
+            lookup("limit-reads", within=config, default=False),
+            then=100000,
+            otherwise=None,
+        ),
         bam_url=get_benchmark_bam_url,
     log:
         "logs/download-reads/{benchmark}.log",

--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -3,7 +3,7 @@ rule get_reads:
         r1="resources/reads/{benchmark}.1.fq",
         r2="resources/reads/{benchmark}.2.fq",
     params:
-        limit=branch(lookup("limit-reads", within=config), then=100000, otherwise=None),
+        limit=branch(lookup("limit-reads", within=config, default=False), then=100000, otherwise=None),
         bam_url=get_benchmark_bam_url,
     log:
         "logs/download-reads/{benchmark}.log",

--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -168,7 +168,7 @@ rule samtools_faidx:
     log:
         "logs/samtools-faidx.log",
     wrapper:
-        "v1.7.2/bio/samtools/faidx"
+        "v6.2.0/bio/samtools/faidx"
 
 
 rule bwa_index:

--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -3,22 +3,15 @@ rule get_reads:
         r1="resources/reads/{benchmark}.1.fq",
         r2="resources/reads/{benchmark}.2.fq",
     params:
-        limit=get_read_limit_param,
+        limit=branch(lookup("limit-reads", within=config), then=100000, otherwise=None),
         bam_url=get_benchmark_bam_url,
     log:
         "logs/download-reads/{benchmark}.log",
     conda:
-        "../envs/tools.yaml"
-    resources:
-        sort_threads=lambda _, threads: max(threads - 2, 1),
-    threads: 32
+        "../envs/pysam.yaml"
     retries: 3
-    shell:
-        "(set +o pipefail; samtools view -f3 -h"
-        " {params.bam_url}"
-        " {params.limit} |"
-        " samtools sort -n -O BAM --threads {resources.sort_threads} | "
-        " samtools fastq -1 {output.r1} -2 {output.r2} -s /dev/null -0 /dev/null -) 2> {log}"
+    script:
+        "scripts/get-reads.py"
 
 
 rule get_archive:

--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -11,7 +11,7 @@ rule get_reads:
         "../envs/pysam.yaml"
     retries: 3
     script:
-        "scripts/get-reads.py"
+        "../scripts/get-reads.py"
 
 
 rule get_archive:

--- a/workflow/rules/utils.smk
+++ b/workflow/rules/utils.smk
@@ -17,4 +17,4 @@ rule index_bcf:
     log:
         "logs/bcftools-index-bcf/{prefix}.log",
     wrapper:
-        "v1.9.0/bio/bcftools/index"
+        "v6.2.0/bio/bcftools/index"

--- a/workflow/scripts/get-reads.py
+++ b/workflow/scripts/get-reads.py
@@ -6,11 +6,11 @@ import pysam
 import dnaio
 
 
-def aln_to_fq(aln):
+def aln_to_fq(qname, aln):
     return dnaio.SequenceRecord(
-        name=aln.query_name,
+        name=qname,
         sequence=aln.get_forward_sequence(),
-        quality=aln.query_qualities,
+        qualities=aln.query_qualities,
     )
 
 
@@ -28,12 +28,12 @@ with dnaio.open(snakemake.output[0], snakemake.output[1], mode="w") as fqwriter:
 
         qname = aln.query_name.removesuffix("/1").removesuffix("/2")
 
-        mate_aln = buffer.get(aln.query_name)
+        mate_aln = buffer.get(qname)
         if mate_aln is None:
-            buffer[aln.query_name] = aln
+            buffer[qname] = aln
         else:
             if aln.is_read2:
                 aln, mate_aln = mate_aln, aln
 
-            fqwriter.write(aln_to_fq(aln), aln_to_fq(mate_aln))
+            fqwriter.write(aln_to_fq(qname, aln), aln_to_fq(qname, mate_aln))
             n_written += 1

--- a/workflow/scripts/get-reads.py
+++ b/workflow/scripts/get-reads.py
@@ -21,7 +21,7 @@ buffer = {}
 n_written = 0
 with dnaio.open(snakemake.output[0], snakemake.output[1], "w") as fqwriter:
     for aln in bam:
-        if n_written >= limit:
+        if limit is not None and n_written >= limit:
             break
         if not aln.is_secondary or aln.is_supplementary:
             continue

--- a/workflow/scripts/get-reads.py
+++ b/workflow/scripts/get-reads.py
@@ -1,0 +1,39 @@
+import sys
+
+sys.stderr = open(snakemake.log[0], "w")
+
+import pysam
+import dnaio
+
+
+def aln_to_fq(aln):
+    return dnaio.SequenceRecord(
+        name=aln.query_name,
+        sequence=aln.get_forward_sequence(),
+        quality=aln.query_qualities,
+    )
+
+
+limit = snakemake.params.limit
+bam = pysam.AlignmentFile(snakemake.params.bam_url)
+
+buffer = {}
+n_written = 0
+with dnaio.open(snakemake.output[0], snakemake.output[1], "w") as fqwriter:
+    for aln in bam:
+        if n_written >= limit:
+            break
+        if not aln.is_secondary or aln.is_supplementary:
+            continue
+
+        qname = aln.query_name.removesuffix("/1").removesuffix("/2")
+
+        mate_aln = buffer.get(aln.query_name)
+        if mate_aln is None:
+            buffer[aln.query_name] = aln
+        else:
+            if aln.is_read2:
+                aln, mate_aln = mate_aln, aln
+
+            fqwriter.write(aln_to_fq(aln), aln_to_fq(mate_aln))
+            n_written += 1

--- a/workflow/scripts/get-reads.py
+++ b/workflow/scripts/get-reads.py
@@ -16,7 +16,7 @@ def aln_to_fq(qname, aln):
     )
 
 
-limit = snakemake.params.limit
+limit = snakemake.params.limit or None
 assert limit is None or limit > 0, "limit must be None or a positive integer"
 bam = pysam.AlignmentFile(snakemake.params.bam_url)
 

--- a/workflow/scripts/get-reads.py
+++ b/workflow/scripts/get-reads.py
@@ -19,7 +19,7 @@ bam = pysam.AlignmentFile(snakemake.params.bam_url)
 
 buffer = {}
 n_written = 0
-with dnaio.open(snakemake.output[0], snakemake.output[1], "w") as fqwriter:
+with dnaio.open(snakemake.output[0], snakemake.output[1], mode="w") as fqwriter:
     for aln in bam:
         if limit is not None and n_written >= limit:
             break

--- a/workflow/scripts/get-reads.py
+++ b/workflow/scripts/get-reads.py
@@ -10,7 +10,9 @@ def aln_to_fq(qname, aln):
     return dnaio.SequenceRecord(
         name=qname,
         sequence=aln.get_forward_sequence(),
-        qualities=aln.query_qualities,
+        qualities="".join(
+            map(lambda qual: chr(qual + 33), aln.get_forward_qualities())
+        ),
     )
 
 

--- a/workflow/scripts/get-reads.py
+++ b/workflow/scripts/get-reads.py
@@ -23,7 +23,7 @@ with dnaio.open(snakemake.output[0], snakemake.output[1], "w") as fqwriter:
     for aln in bam:
         if limit is not None and n_written >= limit:
             break
-        if not aln.is_secondary or aln.is_supplementary:
+        if aln.is_secondary or aln.is_supplementary:
             continue
 
         qname = aln.query_name.removesuffix("/1").removesuffix("/2")

--- a/workflow/scripts/get-reads.py
+++ b/workflow/scripts/get-reads.py
@@ -28,6 +28,8 @@ with dnaio.open(snakemake.output[0], snakemake.output[1], mode="w") as fqwriter:
         if aln.is_secondary or aln.is_supplementary:
             continue
 
+        # Some aligners (e.g. minimap2) add /1 and /2 to the read name.
+        # We remove them here to get the same name for both reads of a pair.
         qname = aln.query_name.removesuffix("/1").removesuffix("/2")
 
         mate_aln = buffer.get(qname)
@@ -36,6 +38,7 @@ with dnaio.open(snakemake.output[0], snakemake.output[1], mode="w") as fqwriter:
         else:
             if aln.is_read2:
                 aln, mate_aln = mate_aln, aln
+            del buffer[qname]
 
             fqwriter.write(aln_to_fq(qname, aln), aln_to_fq(qname, mate_aln))
             n_written += 1

--- a/workflow/scripts/get-reads.py
+++ b/workflow/scripts/get-reads.py
@@ -17,6 +17,7 @@ def aln_to_fq(qname, aln):
 
 
 limit = snakemake.params.limit
+assert limit is None or limit > 0, "limit must be None or a positive integer"
 bam = pysam.AlignmentFile(snakemake.params.bam_url)
 
 buffer = {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new script to extract paired-end reads from BAM files and output them as FASTQ files.

- **Improvements**
  - Updated environment dependencies to include an additional required package.
  - Enhanced the read extraction process for improved accuracy and maintainability.
  - Updated configuration comments to reflect a higher optional read limit.

- **Refactor**
  - Replaced previous shell-based extraction with a dedicated Python script.
  - Simplified configuration and resource handling for the read extraction rule.
  - Updated tool wrapper versions for improved compatibility.
  - Removed deprecated read limit function to streamline processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->