### PR TITLE
fix: remove pipefail statement and switch to wget

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ A Snakemake workflow for benchmarking variant calling approaches with Genome in 
 
 ## Usage
 
-The usage of this workflow is described in the [Snakemake Workflow Catalog](https://snakemake.github.io/snakemake-workflow-catalog/?usage=snakemake-workflows%2Fbenchmark-giab).
+The usage of this workflow is described in the [Snakemake Workflow Catalog](https://snakemake.github.io/snakemake-workflow-catalog/docs/workflows/snakemake-workflows/dna-seq-benchmark.html).
 
 If you use this workflow in a paper, don't forget to give credits to the authors by citing the URL of this (original) benchmark-giabsitory and its DOI (see above).

--- a/workflow/resources/presets.yaml
+++ b/workflow/resources/presets.yaml
@@ -1,14 +1,14 @@
 benchmarks:
   giab-na12878-exome:
     genome: na12878
-    bam-url: ftp://ftp-trace.ncbi.nih.gov/ReferenceSamples/giab/data/NA12878/Nebraska_NA12878_HG001_TruSeq_Exome/NIST-hg001-7001-ready.bam
-    target-regions: ftp://ftp-trace.ncbi.nih.gov/ReferenceSamples/giab/data/NA12878/Nebraska_NA12878_HG001_TruSeq_Exome/TruSeq_exome_targeted_regions.hg19.bed
+    bam-url: https://ftp-trace.ncbi.nih.gov/ReferenceSamples/giab/data/NA12878/Nebraska_NA12878_HG001_TruSeq_Exome/NIST-hg001-7001-ready.bam
+    target-regions: https://ftp-trace.ncbi.nih.gov/ReferenceSamples/giab/data/NA12878/Nebraska_NA12878_HG001_TruSeq_Exome/TruSeq_exome_targeted_regions.hg19.bed
     grch37: true
     high-coverage: false
 
   chm-eval:
     genome: chm-eval
-    bam-url: ftp://ftp.sra.ebi.ac.uk/vol1/run/ERR134/ERR1341796/CHM1_CHM13_2.bam
+    bam-url: https://ftp.sra.ebi.ac.uk/vol1/run/ERR134/ERR1341796/CHM1_CHM13_2.bam
     grch37: false
     high-coverage: false
 

--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -14,7 +14,7 @@ rule get_reads:
     threads: 32
     retries: 3
     shell:
-        "(wget --no-progress -O - {params.bam_url} |"
+        "(wget -nv -O - {params.bam_url} |"
         " samtools sort -n -O BAM --threads {resources.sort_threads} {params.limit} | "
         " samtools fastq -1 {output.r1} -2 {output.r2} -s /dev/null -0 /dev/null -) 2> {log}"
 

--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -14,7 +14,7 @@ rule get_reads:
     threads: 32
     retries: 3
     shell:
-        "(set +o pipefail; samtools view -f3 -h"
+        "(samtools view -f3 -h"
         " {params.bam_url}"
         " {params.limit} |"
         " samtools sort -n -O BAM --threads {resources.sort_threads} | "

--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -14,7 +14,7 @@ rule get_reads:
     threads: 32
     retries: 3
     shell:
-        "(curl {params.bam_url} |"
+        "(curl -L {params.bam_url} |"
         " samtools sort -n -O BAM --threads {resources.sort_threads} {params.limit} | "
         " samtools fastq -1 {output.r1} -2 {output.r2} -s /dev/null -0 /dev/null -) 2> {log}"
 

--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -14,7 +14,7 @@ rule get_reads:
     threads: 32
     retries: 3
     shell:
-        "(wget -O - {params.bam_url} |"
+        "(wget --no-progress -O - {params.bam_url} |"
         " samtools sort -n -O BAM --threads {resources.sort_threads} {params.limit} | "
         " samtools fastq -1 {output.r1} -2 {output.r2} -s /dev/null -0 /dev/null -) 2> {log}"
 

--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -14,9 +14,7 @@ rule get_reads:
     threads: 32
     retries: 3
     shell:
-        "(samtools view -f3 -h"
-        " {params.bam_url}"
-        " {params.limit} |"
+        "(curl {params.bam_url} |"
         " samtools sort -n -O BAM --threads {resources.sort_threads} | "
         " samtools fastq -1 {output.r1} -2 {output.r2} -s /dev/null -0 /dev/null -) 2> {log}"
 

--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -14,7 +14,7 @@ rule get_reads:
     threads: 32
     retries: 3
     shell:
-        "(curl -L {params.bam_url} |"
+        "(wget -O - {params.bam_url} |"
         " samtools sort -n -O BAM --threads {resources.sort_threads} {params.limit} | "
         " samtools fastq -1 {output.r1} -2 {output.r2} -s /dev/null -0 /dev/null -) 2> {log}"
 

--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -15,7 +15,7 @@ rule get_reads:
     retries: 3
     shell:
         "(curl {params.bam_url} |"
-        " samtools sort -n -O BAM --threads {resources.sort_threads} | "
+        " samtools sort -n -O BAM --threads {resources.sort_threads} {params.limit} | "
         " samtools fastq -1 {output.r1} -2 {output.r2} -s /dev/null -0 /dev/null -) 2> {log}"
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the usage section in the README to link directly to the documentation page for the "dna-seq-benchmark" workflow.

- **Refactor**
  - Enhanced BAM file download and processing by switching to direct streaming download and updated sorting parameters.
  - Updated resource URLs from FTP to HTTPS for improved access and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->