### PR TITLE
feat: sort vcfs with shared and unique fp and fn

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -30,11 +30,11 @@ if "variant-calls" in config:
             ),
             get_fp_fn_reports,
             expand(
-                "results/fp-fn/vcf/{benchmark}/{benchmark}.shared_fn.vcf.gz",
+                "results/fp-fn/vcf/{benchmark}/{benchmark}.shared_fn.sorted.vcf.gz",
                 benchmark=used_benchmarks,
             ),
             expand(
-                "results/fp-fn/vcf/{benchmark}/{callset}.unique_{classification}.vcf.gz",
+                "results/fp-fn/vcf/{benchmark}/{callset}.unique_{classification}.sorted.vcf.gz",
                 benchmark=used_benchmarks,
                 callset=used_callsets,
                 classification=["fp", "fn"],

--- a/workflow/rules/utils.smk
+++ b/workflow/rules/utils.smk
@@ -18,3 +18,14 @@ rule index_bcf:
         "logs/bcftools-index-bcf/{prefix}.log",
     wrapper:
         "v7.2.0/bio/bcftools/index"
+
+
+rule sort_vcf:
+    input:
+        "{prefix}.vcf.gz",
+    output:
+        "{prefix}.sorted.vcf.gz",
+    log:
+        "logs/bcftools-sort-vcf/{prefix}.log",
+    wrapper:
+        "v7.2.0/bio/bcftools/sort"


### PR DESCRIPTION
Maybe we can also do this within the script but I thought it would be nice to have sorted vcf files as output to hand back to the different locations.