### PR TITLE
perf: bump snakemake wrappers to v7.8.1

### DIFF
--- a/workflow/rules/compare-vcfs.smk
+++ b/workflow/rules/compare-vcfs.smk
@@ -112,7 +112,7 @@ rule remove_non_pass:
     params:
         extra="-f 'PASS,.'",
     wrapper:
-        "v7.6.1/bio/bcftools/view"
+        "v7.8.1/bio/bcftools/view"
 
 
 rule intersect_calls_with_target_regions:
@@ -208,7 +208,7 @@ rule index_stratified_truth:
     log:
         "logs/bcftools-index/{benchmark}.truth.{cov}.log",
     wrapper:
-        "v7.6.1/bio/bcftools/index"
+        "v7.8.1/bio/bcftools/index"
 
 
 checkpoint stat_truth:

--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -91,7 +91,7 @@ rule normalize_truth:
     log:
         "logs/normalize-truth/{genome}.log",
     wrapper:
-        "v7.6.1/bio/bcftools/norm"
+        "v7.8.1/bio/bcftools/norm"
 
 
 rule get_confidence_bed:
@@ -166,7 +166,7 @@ rule get_reference:
         "logs/get-genome.log",
     cache: "omit-software"  # save space and time with between workflow caching (see docs)
     wrapper:
-        "v7.6.1/bio/reference/ensembl-sequence"
+        "v7.8.1/bio/reference/ensembl-sequence"
 
 
 rule get_liftover_chain:
@@ -188,7 +188,7 @@ rule samtools_faidx:
     log:
         "logs/samtools-faidx.log",
     wrapper:
-        "v7.6.1/bio/samtools/faidx"
+        "v7.8.1/bio/samtools/faidx"
 
 
 rule bwa_index:
@@ -201,7 +201,7 @@ rule bwa_index:
     log:
         "logs/bwa_index/genome.log",
     wrapper:
-        "v7.6.1/bio/bwa/index"
+        "v7.8.1/bio/bwa/index"
 
 
 rule bwa_mem:
@@ -218,7 +218,7 @@ rule bwa_mem:
         sort_order="coordinate",  # Can be 'queryname' or 'coordinate'.
     threads: 8
     wrapper:
-        "v7.6.1/bio/bwa/mem"
+        "v7.8.1/bio/bwa/mem"
 
 
 rule mark_duplicates:
@@ -234,7 +234,7 @@ rule mark_duplicates:
     resources:
         mem_mb=1024,
     wrapper:
-        "v7.6.1/bio/picard/markduplicates"
+        "v7.8.1/bio/picard/markduplicates"
 
 
 rule samtools_index:
@@ -246,7 +246,7 @@ rule samtools_index:
         "logs/samtools-index/{benchmark}.log",
     threads: 4  # This value - 1 will be sent to -@
     wrapper:
-        "v7.6.1/bio/samtools/index"
+        "v7.8.1/bio/samtools/index"
 
 
 rule mosdepth:
@@ -265,7 +265,7 @@ rule mosdepth:
     # additional decompression threads through `--threads`
     threads: 4  # This value - 1 will be sent to `--threads`
     wrapper:
-        "v7.6.1/bio/mosdepth"
+        "v7.8.1/bio/mosdepth"
 
 
 rule stratify_regions:

--- a/workflow/rules/eval-results.smk
+++ b/workflow/rules/eval-results.smk
@@ -81,7 +81,7 @@ rule report_precision_recall:
         genome=get_genome_name,
         version=get_genome_version,
     wrapper:
-        "v7.6.1/utils/datavzrd"
+        "v7.8.1/utils/datavzrd"
 
 
 rule extract_fp_fn:
@@ -263,7 +263,7 @@ rule report_fp_fn:
         labels=lambda w: get_callsets_labels(get_genome_callsets(w.genome)),
         version=get_genome_version,
     wrapper:
-        "v7.6.1/utils/datavzrd"
+        "v7.8.1/utils/datavzrd"
 
 
 rule report_fp_fn_callset:
@@ -293,7 +293,7 @@ rule report_fp_fn_callset:
         somatic=get_somatic_status,
         high_coverage=get_high_coverage_status,
     wrapper:
-        "v7.6.1/utils/datavzrd"
+        "v7.8.1/utils/datavzrd"
 
 
 # TODO: Add rules to include unique and shared fp / fn variants in the report

--- a/workflow/rules/utils.smk
+++ b/workflow/rules/utils.smk
@@ -6,7 +6,7 @@ rule index_vcf:
     log:
         "logs/bcftools-index-vcf/{prefix}.log",
     wrapper:
-        "v7.6.1/bio/bcftools/index"
+        "v7.8.1/bio/bcftools/index"
 
 
 rule index_bcf:
@@ -17,7 +17,7 @@ rule index_bcf:
     log:
         "logs/bcftools-index-bcf/{prefix}.log",
     wrapper:
-        "v7.6.1/bio/bcftools/index"
+        "v7.8.1/bio/bcftools/index"
 
 
 rule sort_vcf:
@@ -28,4 +28,4 @@ rule sort_vcf:
     log:
         "logs/bcftools-sort-vcf/{prefix}.log",
     wrapper:
-        "v7.6.1/bio/bcftools/sort"
+        "v7.8.1/bio/bcftools/sort"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bioinformatics tool wrapper versions (bcftools, samtools, bwa, picard, mosdepth, datavzrd) across workflow processing rules to v7.8.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->