### PR TITLE
fix: avoid creation of vcfs for all callsets for each benchmark

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -34,8 +34,8 @@ if "variant-calls" in config:
                 benchmark=used_benchmarks,
             ),
             expand(
-                "results/fp-fn/vcf/{benchmark}/{benchmark}.unique_{classification}.sorted.vcf.gz",
-                benchmark=used_benchmarks,
+                "results/fp-fn/vcf/{benchmark_callset[0]}/{benchmark_callset[1]}.unique_{classification}.sorted.vcf.gz",
+                benchmark_callset=used_benchmarks_callsets,
                 classification=["fp", "fn"],
             ),
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -23,6 +23,13 @@ used_callsets = {callset for callset in callsets.keys()}
 
 used_genomes = {benchmarks[benchmark]["genome"] for benchmark in used_benchmarks}
 
+used_benchmarks_callsets = [
+    (benchmark, callset)
+    for callset, entries in config["variant-calls"].items()
+    for benchmark in used_benchmarks
+    if entries["benchmark"] == benchmark
+]
+
 
 wildcard_constraints:
     benchmark="|".join(benchmarks),


### PR DESCRIPTION
change wildcard for vcf creation from callset to benchmark to avoid generating to all callset vcfs again for each benchmark

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized FP/FN VCF output layout so variant comparison files are placed under a clearer per‑benchmark/per‑callset directory structure.
  * Updated handling of benchmark–callset pairs so only configured/used pairs produce outputs, reducing spurious or misnamed result files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->