### PR TITLE
fix: change SEQC2 SNV truth to enable VAF comparison for WGS

### DIFF
--- a/workflow/resources/presets.yaml
+++ b/workflow/resources/presets.yaml
@@ -93,7 +93,7 @@ genomes:
     version: 1.2
     truth:
       grch38:
-        snvs: https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/release/latest/high-confidence_sSNV_in_HC_regions_v1.2.vcf.gz
+        snvs: https://zenodo.org/records/18376872/files/high-confidence_sSNV_in_HC_regions_v1.2.rmNeuDiscovered.vcf.gz
         indels: https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/release/latest/high-confidence_sINDEL_in_HC_regions_v1.2.vcf.gz
     confidence-regions:
       grch38: https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/release/latest/High-Confidence_Regions_v1.2.bed


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated somatic SNVs truth reference to use a new hosted file for variant validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->