### PR TITLE
fix: enable liftover for grch37 reference

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -243,11 +243,8 @@ def get_callset(wildcards):
 def get_callset_correct_contigs(wildcards):
     callset = config["variant-calls"][wildcards.callset]
     vcf = callset["path"]
-    if callset.get("rename-contigs", False):
-        return "results/normalized-variants/{callset}.replaced-contigs.vcf.gz"
-    elif callset.get("genome-build", "grch38") == "grch37":
-        return "results/normalized-variants/{callset}.lifted.vcf.gz"
-    elif isinstance(vcf, dict):
+    # Input for liftover must be the pre-liftover callset.
+    if isinstance(vcf, dict):
         return "results/merge-callsets/{callset}.merged.vcf.gz"
     else:
         return get_raw_callset(wildcards)
@@ -258,8 +255,6 @@ def get_callset_correct_contigs_liftover(wildcards):
     vcf = callset["path"]
     if callset.get("genome-build", "grch38") == "grch37":
         return "results/normalized-variants/{callset}.lifted.vcf.gz"
-    elif callset.get("rename-contigs", False):
-        return "results/normalized-variants/{callset}.replaced-contigs.vcf.gz"
     elif isinstance(vcf, dict):
         return "results/merge-callsets/{callset}.merged.vcf.gz"
     else:
@@ -269,7 +264,9 @@ def get_callset_correct_contigs_liftover(wildcards):
 def get_callset_correct_contigs_liftover_merge(wildcards):
     callset = config["variant-calls"][wildcards.callset]
     vcf = callset["path"]
-    if isinstance(vcf, dict):
+    if callset.get("genome-build", "grch38") == "grch37":
+        return "results/normalized-variants/{callset}.lifted.vcf.gz"
+    elif isinstance(vcf, dict):
         return "results/merge-callsets/{callset}.merged.vcf.gz"
     else:
         return get_raw_callset(wildcards)


### PR DESCRIPTION
We should now have this corrected:

config | what is done
-- | --
GRCh38 + rename-contigs=true | raw/merged → rename_contigs → replaced-contigs ✓
GRCh37 + rename-contigs=true | raw/merged → liftover → rename_contigs → replaced-contigs ✓
GRCh38 + rename-contigs=false | raw/merged → (normalize) ✓
GRCh37 + rename-contigs=false | raw/merged → liftover → (normalize) ✓



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced liftover operation handling for GRCh37 genome builds with improved callset processing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->